### PR TITLE
feat: remove buffer options control from user

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Configuration is optional, only needed if you want to override defaults.
 | `icon`           | Icon displayed next to the prompt        | `string`             | N/A                                 |
 | `default_prompt` | Default text for the prompt              | `string`             | N/A                                 |
 | `win_options`    | Window-level Vim options                 | `table<string, any>` | See `:h nvim_win_set_option`        |
-| `buf_options`    | Buffer-level Vim options                 | `table<string, any>` | See `:h nvim_buf_set_option`        |
 | `win_config`     | Window configuration for `nvim_open_win` | `table<string, any>` | See `:h nvim_open_win`              |
 | `width_options`  | Dynamic width settings                   | `table<string, any>` | See [Width Options](#width-options) |
 
@@ -59,7 +58,6 @@ require("input").setup({
         listchars = "precedes:…,extends:…",
         sidescrolloff = 0,
     },
-    buf_options = {},
     win_config = {
         relative = "cursor",
         anchor = "NW",

--- a/lua/input/config.lua
+++ b/lua/input/config.lua
@@ -7,7 +7,6 @@
 ---@field icon string
 ---@field default_prompt string
 ---@field win_options vim.wo
----@field buf_options vim.bo
 ---@field win_config vim.api.keyset.win_config
 ---@field width_options input.width_options
 local config = {}
@@ -21,12 +20,6 @@ local defaults = {
         list = true,
         listchars = "precedes:…,extends:…",
         sidescrolloff = 0,
-    },
-    buf_options = {
-        swapfile = false,
-        buftype = "prompt",
-        bufhidden = "wipe",
-        filetype = "input",
     },
     win_config = {
         relative = "cursor",

--- a/lua/input/init.lua
+++ b/lua/input/init.lua
@@ -1,5 +1,12 @@
 local M = {}
 
+local buf_options = {
+    swapfile = false,
+    buftype = "prompt",
+    bufhidden = "wipe",
+    filetype = "input",
+}
+
 ---@param opts? vim.ui.input.Opts
 ---@param on_confirm fun(input?: string)
 local function input(opts, on_confirm)
@@ -23,7 +30,7 @@ local function input(opts, on_confirm)
     local bufnr = vim.api.nvim_create_buf(false, true)
 
     -- Set buffer options.
-    for option, value in pairs(config.buf_options) do
+    for option, value in pairs(buf_options) do
         vim.bo[bufnr][option] = value
     end
 


### PR DESCRIPTION
Remove buffer option controls from the user to prevent any side effects if someone accidentally changes these values.